### PR TITLE
Ignore query parameters when comparing redirects

### DIFF
--- a/lib/analyzers/redirects/index.js
+++ b/lib/analyzers/redirects/index.js
@@ -2,6 +2,7 @@
 
 let Analyzer = require('../analyzer');
 let logger = require('deelogger')('redirects-analyzer');
+let url = require('url');
 
 class Redirects extends Analyzer {
   constructor() {
@@ -11,45 +12,47 @@ class Redirects extends Analyzer {
 	analyse(campaign, results, callback) {
     this.emit('started', campaign);
 
-    let redirects = results.map(result => result.redirects),
-      diffs = {};
+    //json.parse(json.stringify) is used to make copy of redirects object, don't
+    //want to mess with original result object
+    let uniqueLastStops = results.map(result => JSON.parse(JSON.stringify(result.redirects)))
+      .map(findLastRedirect.bind(null, campaign.details.targetURI))
+      .map((u) => {
+        let parsed = url.parse(u);
 
-    //redirects are an object resource : redirect
-    redirects.forEach((redirectResult) => {
-      Object.keys(redirectResult).forEach((resource) => {
-        redirects.forEach((redirect) => {
-          compareResourceRedirects(resource, redirectResult[resource], redirect[resource], diffs);
-        });
+        return parsed.protocol + '//' + parsed.host + parsed.pathname;
+      })
+      .filter((el, index, arr) => {
+        return arr.indexOf(el) === index;
       });
-    });
+
+    let diff = {};
+
+    if(uniqueLastStops.length > 1) {
+      diff[campaign.details.targetURI] = uniqueLastStops;
+      logger.info('Redirects dont match', {
+        targetURI : campaign.details.targetURI,
+        lastStops : uniqueLastStops
+      });
+    }
 
     callback(null, {
-      correct : Object.keys(diffs).length === 0,
-      diff    : diffs
+      correct : uniqueLastStops.length === 1,
+      diff : diff
     });
 
     this.emit('finished', campaign);
 	}
 }
 
-function compareResourceRedirects(resource, redirect1, redirect2, diffs) {
-  if(redirect1 !== redirect2) {
-    logger.info('Found not matching resource redirect', {
-      resource  : resource,
-      redirect1 : redirect1,
-      redirect2 : redirect2
-    });
-
-    if(!diffs[resource]) {
-      diffs[resource] = [];
-    }
-
-    [redirect1, redirect2].forEach((r) => {
-      if(diffs[resource].indexOf(r) === -1) {
-        diffs[resource].push(r);
-      }
-    });
+function findLastRedirect(targetURI, redirects) {
+  if(redirects[targetURI] === undefined) {
+    return targetURI;
   }
+
+  let newTarget = redirects[targetURI];
+  delete redirects[targetURI];
+
+  return findLastRedirect(newTarget, redirects);
 }
 
 module.exports = Redirects;

--- a/tests/lib/analyzers/redirectsTest.js
+++ b/tests/lib/analyzers/redirectsTest.js
@@ -9,6 +9,9 @@ describe('redirects.js', () => {
   beforeEach(() => {
     redirects = new Redirects();
     campaign = {
+      details : {
+        targetURI : 'http://resource2'
+      },
       _id : 'some id'
     };
   });
@@ -22,20 +25,20 @@ describe('redirects.js', () => {
         }
       }, {
         redirects : {
-          'http://resource1' : 'http://redirect1',
+          'http://resource1' : 'http://redirect4',
           'http://resource2' : 'http://redirect3'
         }
       }], (error, result) => {
         should.not.exist(error);
         result.correct.should.be.equal(false);
         result.diff.should.be.eql({
-          'http://resource2' : ['http://redirect2', 'http://redirect3']
+          'http://resource2' : ['http://redirect2/', 'http://redirect3/']
         });
         done();
       });
     });
 
-    it('should return true if all redirects match', (done) => {
+    it('should return true if page redirect matches even if secondary redirects dont', (done) => {
       redirects.analyse(campaign, [{
         redirects : {
           'http://resource1' : 'http://redirect1',
@@ -45,6 +48,44 @@ describe('redirects.js', () => {
         redirects : {
           'http://resource1' : 'http://redirect1',
           'http://resource2' : 'http://redirect2'
+        }
+      }], (error, result) => {
+        should.not.exist(error);
+        result.correct.should.be.equal(true);
+        result.diff.should.be.eql({});
+        done();
+      });
+    });
+
+    it('should not go in endless loop if there is loop in redirects', (done) => {
+      redirects.analyse(campaign, [{
+        redirects : {
+          'http://resource1' : 'http://resource2',
+          'http://resource2' : 'http://resource1'
+        }
+      }, {
+        redirects : {
+          'http://resource1' : 'http://resource2',
+          'http://resource2' : 'http://resource1'
+        }
+      }], (error, result) => {
+        should.not.exist(error);
+        done();
+      });
+    });
+
+    it('should drop query parameters when comparing unique addresses', (done) => {
+      redirects.analyse(campaign, [{
+        redirects : {
+          'http://resource2' : 'http://redirect2?test=1',
+          'http://redirect2?test=1' : 'http://redirect2?test=3',
+          'http://redirect2?test=3' : 'http://resource1/something?test=4'
+        }
+      }, {
+        redirects : {
+          'http://resource2' : 'http://redirect1?test=1',
+          'http://redirect1?test=1' : 'http://redirect2?test=3',
+          'http://redirect2?test=3' : 'http://resource1/something?test=5'
         }
       }], (error, result) => {
         should.not.exist(error);


### PR DESCRIPTION
Also compare only redirect path for target uri ignoring other resources as they might have session id or other unique identifiers in their resource url(#23)
