### PR TITLE
Tagging jobs and campaigns by site categories, fixes #37, also fixes #32

### DIFF
--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -25,7 +25,7 @@ module.exports = function(argv) {
       id : result.id
     });
 
-    jobModel.updateWithResult(result.id, result.result, (error) => {
+    jobModel.updateWithResult(result.id, result.jobDetails, result.result, (error) => {
       if(error) {
         logger.error('Failed to update job with results', {
           id    : result.id,

--- a/lib/jobQueue.js
+++ b/lib/jobQueue.js
@@ -186,8 +186,9 @@ class JobQueue extends EventEmitter {
     })
     .then(() => {
       this.emit('jobResult', {
-        id     : id,
-        result : result
+        id         : id,
+        result     : result,
+	jobDetails : jobDetails
       });
 
       logger.debug('Tab sequence executed', {

--- a/lib/jobQueue.js
+++ b/lib/jobQueue.js
@@ -188,7 +188,7 @@ class JobQueue extends EventEmitter {
       this.emit('jobResult', {
         id         : id,
         result     : result,
-	jobDetails : jobDetails
+        jobDetails : jobDetails
       });
 
       logger.debug('Tab sequence executed', {

--- a/lib/models/campaign.js
+++ b/lib/models/campaign.js
@@ -3,7 +3,8 @@
 let Model = require('./model'),
   logger = require('deelogger')('Model-Campaign'),
   tldextract = require('tldextract'),
-  topsites = require('../site-toplists/topSiteListings');
+  topsites = require('moz-data-site-toplists');
+
 
 class Campaign extends Model {
   constructor(couchDBSettings, dbName) {

--- a/lib/models/campaign.js
+++ b/lib/models/campaign.js
@@ -1,7 +1,9 @@
 "use strict";
 
 let Model = require('./model'),
-  logger = require('deelogger')('Model-Campaign');
+  logger = require('deelogger')('Model-Campaign'),
+  tldextract = require('tldextract'),
+  topsites = require('../site-toplists/topSiteListings');
 
 class Campaign extends Model {
   constructor(couchDBSettings, dbName) {
@@ -33,59 +35,65 @@ class Campaign extends Model {
   }
 
   addFromGithub(githubIssue, callback) {
-    let id = 'github-' + githubIssue.id,
-      doc = {
-        status       : 'open',
-        created      : new Date(),
-        autoTests    : [],
-        autoTestable : true,
-        from         : 'github',
-        runCount     : 0,
-        details : {
-          targetURI  : githubIssue.url,
-          type       : githubIssue.forMobile ? 'mobile' : 'desktop',
-          userAgents : [githubIssue.userAgent], //user agent that was extracted from github issue
-          engines    : [githubIssue.engine]
-        },
-        github : {
-          issueUrl : githubIssue.issueUrl,
-          id       : githubIssue.id,
-          number   : githubIssue.number
-        },
-      };
+    tldextract(githubIssue.url, function handleDomainData(error, result){
+      let id = 'github-' + githubIssue.id,
+        domain = (result) ? result.domain + '.' + result.tld : '',
+	tags = topsites.countryLists(domain),
+        doc = {
+          status       : 'open',
+          created      : new Date(),
+          autoTests    : [],
+          autoTestable : true,
+          from         : 'github',
+          runCount     : 0,
+          details : {
+            targetURI  : githubIssue.url,
+	    domain     : domain,
+	    tags       : tags,
+            type       : githubIssue.forMobile ? 'mobile' : 'desktop',
+            userAgents : [githubIssue.userAgent], //user agent that was extracted from github issue
+            engines    : [githubIssue.engine]
+          },
+          github : {
+            issueUrl : githubIssue.issueUrl,
+            id       : githubIssue.id,
+            number   : githubIssue.number
+          },
+        };
 
-    //by default connection is using cradle forcenew option,
-    //it allows to skip fetching and using rev number it will fetch
-    //it whenever put fails, but it also means that there is no way
-    //how to check if document already exists, it won't return an error
-    //so manual check is required
-    this._db.head(id, (err, res, status) => {
-      if(err) {
-        return callback(err);
-      }
+      //by default connection is using cradle forcenew option,
+      //it allows to skip fetching and using rev number it will fetch
+      //it whenever put fails, but it also means that there is no way
+      //how to check if document already exists, it won't return an error
+      //so manual check is required
+      this._db.head(id, (err, res, status) => {
+        if(err) {
+          return callback(err);
+       }
 
-      //there is no point in adding job documents for already closed
-      //issues
-      if(status === 404 && githubIssue.status === 'closed') {
-        return callback();
-      }
+        //there is no point in adding job documents for already closed
+        //issues
+        if(status === 404 && githubIssue.status === 'closed') {
+          return callback();
+        }
 
-      //update on already existing document should be done only
-      //if corresponding github issue gets closed
-      if(status !== 404 && githubIssue.status !== 'closed') {
-        logger.debug('Job for issue ' + githubIssue.number + ' already exists');
-        return callback();
-      }
+        //update on already existing document should be done only
+        //if corresponding github issue gets closed
+        if(status !== 404 && githubIssue.status !== 'closed') {
+          logger.debug('Job for issue ' + githubIssue.number + ' already exists');
+          return callback();
+        }
 
-      if(githubIssue.status === 'closed') {
-        this._db.merge(id, {
-          status : 'closed',
-          closedAt : new Date()
-        }, callback);
-      } else {
-        this._db.save(id, doc, callback);
-      }
-    });
+        if(githubIssue.status === 'closed') {
+          this._db.merge(id, {
+            status : 'closed',
+            closedAt : new Date()
+          }, callback);
+        } else {
+          this._db.save(id, doc, callback);
+        }
+      });
+    }.bind(this));
   }
 
   getOpenJobs(callback) {

--- a/lib/models/campaign.js
+++ b/lib/models/campaign.js
@@ -38,7 +38,7 @@ class Campaign extends Model {
     tldextract(githubIssue.url, function handleDomainData(error, result){
       let id = 'github-' + githubIssue.id,
         domain = (result) ? result.domain + '.' + result.tld : '',
-	tags = topsites.countryLists(domain),
+        tags = topsites.countryLists(domain),
         doc = {
           status       : 'open',
           created      : new Date(),
@@ -48,8 +48,8 @@ class Campaign extends Model {
           runCount     : 0,
           details : {
             targetURI  : githubIssue.url,
-	    domain     : domain,
-	    tags       : tags,
+            domain     : domain,
+            tags       : tags,
             type       : githubIssue.forMobile ? 'mobile' : 'desktop',
             userAgents : [githubIssue.userAgent], //user agent that was extracted from github issue
             engines    : [githubIssue.engine]
@@ -69,7 +69,7 @@ class Campaign extends Model {
       this._db.head(id, (err, res, status) => {
         if(err) {
           return callback(err);
-       }
+        }
 
         //there is no point in adding job documents for already closed
         //issues
@@ -93,7 +93,7 @@ class Campaign extends Model {
           this._db.save(id, doc, callback);
         }
       });
-    }.bind(this));
+    }.bind(this)); // bind handleDomainData() to outer this
   }
 
   getOpenJobs(callback) {

--- a/lib/models/job.js
+++ b/lib/models/job.js
@@ -2,7 +2,9 @@
 
 let Model = require('./model'),
   logger = require('deelogger')('Model-Job'),
-  async = require('async');
+  async = require('async'),
+  tldextract = require('tldextract'),
+  topsites = require('../site-toplists/topSiteListings');
 
 class Job extends Model{
   constructor(couchDBSettings, dbName) {
@@ -79,7 +81,14 @@ class Job extends Model{
       data : result.screenshot
     };
 
-    this._db.merge(id, updateObj, callback);
+    updateObj.jobDetails = details;
+    tldextract(details.targetURI, function handleDomainData(error, result){
+      let domain = (result ? result.domain + '.' + result.tld : '');
+      updateObj.jobDetails.domain = domain;
+      updateObj.jobDetails.tags = topsites.countryLists(updateObj.jobDetails.domain);
+
+      this._db.merge(id, updateObj, callback);
+    }.bind(this));
   }
 
   markAsInvalid(id, callback) {
@@ -107,7 +116,11 @@ class Job extends Model{
       runNumber  : runNumber
     };
 
-    this._db.save(doc, callback);
+    tldextract(jobDetails.targetURI, function handleDomainData(error, result){
+      doc.jobDetails.domain = result.domain + '.' + result.tld;
+      doc.jobDetails.tags = topsites.countryLists(domain);
+      this._db.save(doc, callback);
+    }.bind(this));
   }
 
   startListening() {

--- a/lib/models/job.js
+++ b/lib/models/job.js
@@ -58,7 +58,7 @@ class Job extends Model{
     }, callback);
   }
 
-  updateWithResult(id, result, callback) {
+  updateWithResult(id, details, result, callback) {
     let updateObj = {
         status : 'completed',
         jobResults : {},

--- a/lib/models/job.js
+++ b/lib/models/job.js
@@ -4,7 +4,8 @@ let Model = require('./model'),
   logger = require('deelogger')('Model-Job'),
   async = require('async'),
   tldextract = require('tldextract'),
-  topsites = require('../site-toplists/topSiteListings');
+  topsites = require('moz-data-site-toplists');
+
 
 class Job extends Model{
   constructor(couchDBSettings, dbName) {

--- a/lib/models/job.js
+++ b/lib/models/job.js
@@ -119,7 +119,7 @@ class Job extends Model{
 
     tldextract(jobDetails.targetURI, function handleDomainData(error, result){
       doc.jobDetails.domain = result.domain + '.' + result.tld;
-      doc.jobDetails.tags = topsites.countryLists(domain);
+      doc.jobDetails.tags = topsites.countryLists(doc.jobDetails.domain);
       this._db.save(doc, callback);
     }.bind(this));
   }

--- a/lib/serialExecutor.js
+++ b/lib/serialExecutor.js
@@ -148,7 +148,7 @@ class SerialExecutor {
           this._tabSequence.execute.bind(this._tabSequence, job._id, job.jobDetails),
           (result, cb) => {
             if(result.success) {
-              this._jobModel.updateWithResult(result.id, result.result, cb);
+              this._jobModel.updateWithResult(result.id, result.jobDetails, result.result, cb);
             } else {
               this._accumulator[campaignId].error = result.errors.map(e => e.message).join('; ');
               this._jobModel.markAsFailed(result.id, result.errors, cb);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "request": "^2.65.0",
     "statsd-client": "^0.2.1",
     "sugar": "^1.4.1",
+    "tldextract": "^0.0.4",
     "useragent": "^2.1.8",
     "valid-url": "^1.0.9",
     "yargs": "^3.29.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "tldextract": "^0.0.4",
     "useragent": "^2.1.8",
     "valid-url": "^1.0.9",
-    "yargs": "^3.29.0"
+    "yargs": "^3.29.0",
+    "moz-data-site-toplists": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "useragent": "^2.1.8",
     "valid-url": "^1.0.9",
     "yargs": "^3.29.0",
-    "moz-data-site-toplists": "^1.0.0"
+    "moz-data-site-toplists": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "^2.3.3",
@@ -42,5 +42,6 @@
     "mockery": "^1.4.0",
     "nock": "^2.15.0",
     "should": "^7.1.1"
-  }
+  },
+  "repository": "https://github.com/mozilla/compatipede"
 }

--- a/tests/lib/jobQueue.js
+++ b/tests/lib/jobQueue.js
@@ -333,7 +333,13 @@ describe('jobQueue', () => {
             },
             pluginResults : {
               somePlugin : {}
-            }
+            },
+          },
+          jobDetails : {
+            engine : 'gecko',
+            userAgent : 'some gecko ua',
+            screenSize : { width : 1024, height : 1024 },
+            targetURI : 'https://google.com'
           }
         });
 

--- a/tests/lib/models/campaignTest.js
+++ b/tests/lib/models/campaignTest.js
@@ -2,7 +2,10 @@
 
 let Campaign = require('../../../lib/models/campaign'),
   should = require('should'),
-  mockCouch = require('mock-couch');
+  mockCouch = require('mock-couch'),
+  topsites = require('moz-data-site-toplists');
+
+topsites.enableTestMode();
 
 describe('campaign', () => {
   let couchdb, campaign;
@@ -58,6 +61,8 @@ describe('campaign', () => {
         doc.runCount.should.be.equal(0);
         doc.details.should.be.eql({
           targetURI  : 'https://google.com',
+          domain     : 'google.com',
+          tags       : [ '1000', 'us50' ],
           type       : 'mobile',
           userAgents : ['someUserAgentFromBug'],
           engines    : ['gecko']
@@ -69,7 +74,6 @@ describe('campaign', () => {
         });
         done();
       });
-
       campaign.addFromGithub(githubIssue, () => {});
     });
 

--- a/tests/lib/models/jobTest.js
+++ b/tests/lib/models/jobTest.js
@@ -68,7 +68,7 @@ describe('job', () => {
         done();
       });
 
-      job.updateWithResult('correctJobId', {}, {
+      job.updateWithResult('correctJobId', {'targetURI':'http://test.example.com'}, {
         resources : {
           something : 'test'
         },
@@ -150,7 +150,8 @@ describe('job', () => {
       });
 
       job.createNewRun('someJobId', 666, {
-        engine : 'webkit'
+        engine : 'webkit',
+        targetURI:'http://test.example.com'
       }, () => {});
     });
   });

--- a/tests/lib/models/jobTest.js
+++ b/tests/lib/models/jobTest.js
@@ -68,7 +68,7 @@ describe('job', () => {
         done();
       });
 
-      job.updateWithResult('correctJobId', {
+      job.updateWithResult('correctJobId', {}, {
         resources : {
           something : 'test'
         },

--- a/tests/lib/models/jobTest.js
+++ b/tests/lib/models/jobTest.js
@@ -2,7 +2,10 @@
 
 let should = require('should'),
   Job = require('../../../lib/models/job'),
-  mockCouch = require('mock-couch');
+  mockCouch = require('mock-couch'),
+  topsites = require('moz-data-site-toplists');
+
+topsites.enableTestMode();
 
 describe('job', () => {
   let couchdb, job;
@@ -44,9 +47,11 @@ describe('job', () => {
 
     it('should update job with results', (done) => {
       couchdb.on('PUT', (data) => {
-
         data.doc.jobDetails.should.be.eql({
-          engine : 'gecko'
+          engine : 'gecko',
+          targetURI : 'http://test.example.com',
+          domain : "example.com",
+          tags : []
         });
         data.doc.jobResults.resources.should.be.eql({
             something : 'test'
@@ -68,7 +73,7 @@ describe('job', () => {
         done();
       });
 
-      job.updateWithResult('correctJobId', {'targetURI':'http://test.example.com'}, {
+      job.updateWithResult('correctJobId', {targetURI : 'http://test.example.com', engine : 'gecko'}, {
         resources : {
           something : 'test'
         },
@@ -144,7 +149,10 @@ describe('job', () => {
         data.doc.jobId.should.be.equal('someJobId');
         data.doc.runNumber.should.be.equal(666);
         data.doc.jobDetails.should.be.eql({
-          engine : 'webkit'
+          engine : 'webkit',
+          targetURI : 'http://test.example.com',
+          domain : 'example.com',
+          tags : []
         });
         done();
       });

--- a/tests/lib/serialExecutorTest.js
+++ b/tests/lib/serialExecutorTest.js
@@ -275,7 +275,7 @@ describe('serialExecutor', () => {
         }]);
       };
 
-      jobModel.updateWithResult = (id, result, callback) => {
+      jobModel.updateWithResult = (id, details, result, callback) => {
         callback();
       };
 
@@ -334,7 +334,7 @@ describe('serialExecutor', () => {
 
     it('should update job with results if execution suceeded', (done) => {
       let calledWith = [];
-      jobModel.updateWithResult = (id, result, cb) => {
+      jobModel.updateWithResult = (id, details, result, cb) => {
         calledWith.push({
           id     : id,
           result : result


### PR DESCRIPTION
The simplest way to do this was as far as I could tell to change the updateWithResults() function signature to also receive the old details. Doing something else would mean another roundtrip to the DB to get current values.
